### PR TITLE
Load UBDiag upload image from Harbor cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,8 @@ inputs:
     required: true
 runs:
   using: 'docker'
-  image: 'docker://ubinnovation/android-ubdiag-upload:v1.1.0'
+  container:
+    image: 'docker://harbor.office.ubique.rocks/dockerhub-public-cache/ubinnovation/android-ubdiag-upload:v1.1.0'
   entrypoint: '/main.sh'
   args:
     - ${{ inputs.buildNumber }}


### PR DESCRIPTION
Harbor transparently pulls and caches images from Docker Hub.
This avoids issues with Docker Hub rate limits and potentially speeds up selfhosted runners